### PR TITLE
Update go namespace in cljs

### DIFF
--- a/src/async_error/core.cljc
+++ b/src/async_error/core.cljc
@@ -44,7 +44,7 @@
      "Like go but catches the first thrown error and returns it."
      [& body]
      `(if-cljs
-        (cljs.core.async.macros/go
+        (cljs.core.async/go
           (try
             ~@body
             (catch js/Error e# e#)))


### PR DESCRIPTION
Hey, thanks for putting together this package! I think you need to refer to `go` as `cljs.core.async/go` instead of `cljs.core.async.macros/go`. I was getting that the `cljs.core.async.macros` namespace didn't exist, but this seems to get the job done.

Cheers!